### PR TITLE
Create initial gulp file

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -14,7 +14,7 @@
     "regexp": true,
     "undef": true,
     "unused": true,
-    "strict": true,
+    "strict": false,
     "trailing": true,
     "smarttabs": true,
     "white": true

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,20 @@
+var gulp = require('gulp');
+
+// loading packages
+var gutil = require('gulp-util');
+var jshint = require('gulp-jshint');
+
+// configure the jshint task
+gulp.task('jshint', function() {
+  return gulp.src('app/src/**/*.js')
+    .pipe(jshint())
+    .pipe(jshint.reporter('jshint-stylish'));
+});
+
+// configure which files to watch and what tasks to run on file changes
+gulp.task('watch', function() {
+  gulp.watch('app/src/**/*.js', ['jshint']);
+});
+
+// define the default task and add watch task to it
+gulp.task('default', ['jshint', 'watch']);

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
   "homepage": "https://github.com/general-porpoise/snapcache",
   "devDependencies": {
     "jest-cli": "^0.4.0"
+    "gulp": "^3.8.11",
+    "gulp-jshint": "^1.10.0",
+    "gulp-util": "^3.0.4",
+    "jshint-stylish": "^1.0.1"
   },
   "scripts": {
     "test": "jest"


### PR DESCRIPTION
Running `gulp` in the root directory will currently only perform watching and linting on file changes. 

We may want to have a discussion on what exact files we plan on linting (and other associated gulp tasks). It is currently set such that all JavaScript files in `app/src/**.*.js` will be watched/linted.

We will eventually need to build out this gulp file, but I figured it made more sense to just get something started. 

Closes #3 