### PR TITLE
(fix) Update gitignore for www/lib and www/css

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,10 @@ node_modules/
 platforms/
 plugins/
 docs/
+
+# Ignoring files from Gulp CSS Pre-processor
+www/css/ionic.app.css
+www/css/ionic.app.min.css
+
+# Ignoring files from bower install
+www/lib


### PR DESCRIPTION
This ignores files that result from both the Gulp task of compiling
CSS and ones that are installed when you do `bower install`.
