### PR TITLE
(feat) Link Create Cache to Cache Service

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "firebase": "~2.2.3",
     "angularfire": "~1.0.0",
-    "moment": "~2.10.0"
+    "moment": "~2.10.0",
+    "lodash": "~3.6.0"
   }
 }

--- a/www/index.html
+++ b/www/index.html
@@ -36,7 +36,7 @@
   <body ng-app="snapcache">
     <ion-nav-view></ion-nav-view>
     <script src="http://maps.googleapis.com/maps/api/js?libraries=places&sensor=true"></script>
-    <script src="lib/lodash/dist/lodash.min.js"></script>
     <script src="lib/moment/moment.js"></script>
+    <script src="lib/lodash/lodash.min.js"></script>
   </body>
 </html>

--- a/www/js/auth/AuthCtrl.js
+++ b/www/js/auth/AuthCtrl.js
@@ -1,7 +1,7 @@
 // Authentication controller
 angular.module('snapcache.auth', [])
 
-.controller('AuthCtrl', function($location, FirebaseAuth) {
+.controller('AuthCtrl', function($location, FirebaseAuth, userSession) {
 
   var self = this;
 
@@ -23,14 +23,16 @@ angular.module('snapcache.auth', [])
     } else {
       self.signup();
     }
-  }
+  };
 
   // Use Authentication service to login user
   self.login = function() {
     console.log('Logging in');
 
-    // TODO: login user
     FirebaseAuth.login().then(function(uid){
+      // Setting the user's id so that it can be accessed anywhere that
+      // the value "userSession" is injected.
+      userSession.uid = uid;
       console.log('the users id is:', uid);
 
       // Redirect to inbox after successful login

--- a/www/js/create/CreateCtrl.js
+++ b/www/js/create/CreateCtrl.js
@@ -1,13 +1,18 @@
 // Create Controller
 angular.module('snapcache.create', [])
 
-.controller('CreateCtrl', function($scope, $ionicModal, $timeout, Caches) {
+.controller('CreateCtrl', function($scope, $ionicModal, $timeout, Caches, userSession) {
 
   var self = this;
   self.properties = {};
 
   self.submitNewCache = function() {
     console.log('New cache submitted');
+
+    // Adding the user's id so that we can know what user(s) to associate
+    // this created cache with in Firebase.)
+    self.properties.contributors = {};
+    self.properties.contributors[userSession.uid] = true;
     Caches.create(self.properties);
   };
 

--- a/www/js/create/CreateCtrl.js
+++ b/www/js/create/CreateCtrl.js
@@ -1,15 +1,15 @@
 // Create Controller
 angular.module('snapcache.create', [])
 
-.controller('CreateCtrl', function($scope, $ionicModal, $timeout) {
-  
+.controller('CreateCtrl', function($scope, $ionicModal, $timeout, Caches) {
+
   var self = this;
   self.properties = {};
 
   self.submitNewCache = function() {
     console.log('New cache submitted');
+    Caches.create(self.properties);
   };
-
 
   // Create the map modal that we will use later
   $ionicModal.fromTemplateUrl('js/create/map.html', {
@@ -81,7 +81,7 @@ angular.module('snapcache.create', [])
         console.log(placeNodes[i]);
         placeNodes[i].addEventListener('click', function() {
           console.log('clicked');
-        });        
+        });
       }
     }, 400);
   }

--- a/www/js/shared/CachesService.js
+++ b/www/js/shared/CachesService.js
@@ -15,7 +15,8 @@ angular.module('snapcache.services.caches', [])
 
   // `getContributable()` will get the current user's caches that they can
   // contribute to from Firebase.
-  function getContributable(id) {
+  function getContributable() {
+    var id = userSession.uid;
     var deferred = $q.defer();
     usersRef.child(id).once('value', function(snapshot){
       var userData = snapshot.val();
@@ -36,7 +37,8 @@ angular.module('snapcache.services.caches', [])
   // but that will be added in the future.
   //
   // TODO: Add temporal and geographic filtering
-  function getReceived(id) {
+  function getReceived() {
+    var id = userSession.uid;
     var deferred = $q.defer();
     usersRef.child(id).once('value', function(snapshot){
       var userData = snapshot.val();

--- a/www/js/snapcache.js
+++ b/www/js/snapcache.js
@@ -16,7 +16,7 @@ angular.module('snapcache', [
   ])
 
 .value('FIREBASE_REF', 'https://brilliant-heat-4193.firebaseio.com/')
-.value('userSession', {})
+.value('userSession', {uid: ''})
 
 .run(function($ionicPlatform) {
   $ionicPlatform.ready(function() {


### PR DESCRIPTION
This pull request does the following:
1. Wire up the submitNewCache() to the Caches Service
2. Add the user's id so that Firebase where know what user to associate the created cache with
3. Change getContributable() and getReceivable() to no longer need the id input since we can just access the currently logged in user's id.

I ended up being able to use the userSession value after all, so if any controller needs access to that, it is as easy as injecting userSession and then calling userSession.uid
