### PR TITLE
(fix) Fix facebook auth to reliably respond on mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,7 @@
     "karma-jasmine": "^0.3.5",
     "shelljs": "^0.3.0"
   },
-  "cordovaPlugins": []
+  "cordovaPlugins": [
+    "org.apache.cordova.inappbrowser"
+  ]
 }

--- a/www/js/auth/AuthCtrl.js
+++ b/www/js/auth/AuthCtrl.js
@@ -1,7 +1,7 @@
 // Authentication controller
 angular.module('snapcache.auth', [])
 
-.controller('AuthCtrl', function($location, FirebaseAuth, userSession) {
+.controller('AuthCtrl', function($location, $ionicLoading, FirebaseAuth, userSession) {
 
   var self = this;
 
@@ -25,15 +25,32 @@ angular.module('snapcache.auth', [])
     }
   };
 
+  // Shows loading message
+  self.showLoading = function() {
+    $ionicLoading.show({
+      template: 'Logging in...'
+    });
+  };
+
+  // Hides loading message
+  self.hideLoading = function(){
+    $ionicLoading.hide();
+  };
+
   // Use Authentication service to login user
   self.login = function() {
     console.log('Logging in');
+    // show loading message while logging in
+    self.showLoading();
 
     FirebaseAuth.login().then(function(uid){
       // Setting the user's id so that it can be accessed anywhere that
       // the value "userSession" is injected.
       userSession.uid = uid;
       console.log('the users id is:', uid);
+
+      // Hide loading message when firebase returns
+      self.hideLoading();
 
       // Redirect to inbox after successful login
       $location.path('/app/inbox');

--- a/www/js/shared/FirebaseAuthService.js
+++ b/www/js/shared/FirebaseAuthService.js
@@ -14,37 +14,41 @@ angular.module('snapcache.services.auth', [])
 
   function login() {
     var deferred = $q.defer();
+
+    // Listen for changes in Auth state of app
+    usersRef.onAuth(function(authData) {
+      console.log("Authenticated successfully with payload:", authData);
+
+      // See if the returned uid is present in database
+      usersRef.child(authData.uid).once('value', function(snapshot){
+        var userObj = snapshot.val();
+
+        // If the user is present in the database, return the user object after
+        // updating with any new Facebook data. Otherwise create a new user in the
+        //  database with uid as unique key.
+        if (userObj) {
+          userSession.uid = authData.uid;
+          usersRef.child(authData.uid).child('data').set(authData);
+          console.log('user already exists in database');
+        } else {
+          // Setting the new user object in Firebase
+          usersRef.child(authData.uid).child('data').set(authData);
+          console.log('new user added to the database');
+        }
+
+        // Attempting to use promises
+        if (authData.uid) {
+          deferred.resolve(authData.uid);
+        } else {
+          deferred.reject('woops!');
+        }
+      });
+    });
+
     // Authenticate using Facebook
-    usersRef.authWithOAuthPopup("facebook", function(error, authData) {
+    usersRef.authWithOAuthRedirect("facebook", function(error, authData) {
       if (error) {
         console.log("Login Failed!", error);
-      } else {
-        console.log("Authenticated successfully with payload:", authData);
-
-        // See if the returned uid is present in database
-        usersRef.child(authData.uid).once('value', function(snapshot){
-          var userObj = snapshot.val();
-
-          // If the user is present in the database, return the user object after
-          // updating with any new Facebook data. Otherwise create a new user in the
-          //  database with uid as unique key.
-          if (userObj) {
-            userSession.uid = authData.uid;
-            usersRef.child(authData.uid).child('data').set(authData);
-            console.log('user already exists in database');
-          } else {
-            // Setting the new user object in Firebase
-            usersRef.child(authData.uid).child('data').set(authData);
-            console.log('new user added to the database');
-          }
-
-          // Attempting to use promises
-          if (authData.uid) {
-            deferred.resolve(authData.uid);
-          } else {
-            deferred.reject('woops!');
-          }
-        });
       }
     }, {
       // This causes Facebook to give us a token that will grant access


### PR DESCRIPTION
Firebase auth (with facebook) now uses the authWithOAuthRedirect
method rather than the authWithOAuthPopup, which seems to work more
consistently on mobile devices.

The app now uses the "inappbrowser" cordova plugin, which fixes
issues with OAuth redirects/popups hanging on a blank page.

Finally, the auth page now shows a loading message while awaiting
response from firebase/facebook auth services.

close #42 
