### PR TITLE
(feat) Allow users to search through Facebook Friends as recipients

### DIFF
--- a/www/js/auth/AuthCtrl.js
+++ b/www/js/auth/AuthCtrl.js
@@ -43,19 +43,7 @@ angular.module('snapcache.auth', [])
     // show loading message while logging in
     self.showLoading();
 
-    FirebaseAuth.login().then(function(uid){
-      // Setting the user's id so that it can be accessed anywhere that
-      // the value "userSession" is injected.
-      userSession.uid = uid;
-
-      // TODO: Currently hard-coding the user's friends. We will probably want to get this
-      // list in FirebaseAuthService when the user logs in
-      userSession.friends = [
-        {name: 'Conor Flannigan', uid: 'facebook:10204075896841208'},
-        {name: 'Anneke Floor', uid: 'facebook:10206286278296373'}
-      ];
-
-      console.log('the users id is:', uid);
+    FirebaseAuth.login().then(function(){
 
       // Hide loading message when firebase returns
       self.hideLoading();

--- a/www/js/create/CreateCtrl.js
+++ b/www/js/create/CreateCtrl.js
@@ -22,10 +22,10 @@ angular.module('snapcache.create', [])
     // Collapse the list of potential recipients once the user clicks
     // on the friend they are sending the cache to.
     self.potentialRecipients = [];
-    
-    // Attach the friend uid to the object that will be sent over to Firebase
+
+    // Attach the friend's id to the object that will be sent over to Firebase
     self.properties.recipients = {};
-    self.properties.recipients[friend.uid] = true;
+    self.properties.recipients['facebook:' + friend.id] = true;
   };
 
   self.submitNewCache = function() {

--- a/www/js/shared/FirebaseAuthService.js
+++ b/www/js/shared/FirebaseAuthService.js
@@ -32,20 +32,11 @@ angular.module('snapcache.services.auth', [])
 
       // See if the returned uid is present in database
       usersRef.child(authData.uid).once('value', function(snapshot){
-        var userObj = snapshot.val();
 
-        // If the user is present in the database, return the user object after
-        // updating with any new Facebook data. Otherwise create a new user in the
-        //  database with uid as unique key.
-        if (userObj) {
-          userSession.uid = authData.uid;
-          usersRef.child(authData.uid).child('data').set(authData);
-          console.log('user already exists in database');
-        } else {
-          // Setting the new user object in Firebase
-          usersRef.child(authData.uid).child('data').set(authData);
-          console.log('new user added to the database');
-        }
+        // No matter if the user is new or existing, we just need to update
+        // their data property (if they are new, their entire tree will be created).
+        userSession.uid = authData.uid;
+        usersRef.child(authData.uid).child('data').set(authData);
 
         // Attempting to use promises
         if (authData.uid) {

--- a/www/js/shared/FirebaseAuthService.js
+++ b/www/js/shared/FirebaseAuthService.js
@@ -30,7 +30,8 @@ angular.module('snapcache.services.auth', [])
     usersRef.onAuth(function(authData) {
       console.log("Authenticated successfully with payload:", authData);
 
-      // See if the returned uid is present in database
+      // We will update or add to Firebase based on the users uid returned
+      // from the authData object.
       usersRef.child(authData.uid).once('value', function(snapshot){
         // Storing certain information on userSession for access anywhere in app.
         userSession.uid = authData.uid;
@@ -39,24 +40,23 @@ angular.module('snapcache.services.auth', [])
         // their data property (if they are new, their entire tree will be created).
         usersRef.child(authData.uid).child('data').set(authData);
 
-        // Want to get the users friends and save to userSession object
+        //Get the user's friends and save to userSession object
         var fbId = authData.facebook.id;
         var fbToken = authData.facebook.accessToken;
         $http.get('https://graph.facebook.com/v2.3/' + fbId + '/friends?access_token=' + fbToken)
+          // If we get a response back from Facebook, then we will resolve our promise with the
+          // knowledge that the the user's friends are on the userSession object.
           .success(function(response){
             userSession.friends = response.data;
             console.log('your facebook friend data is', userSession.friends);
+            deferred.resolve();
           })
+          // If we don't get a response, then we will reject our promise.
           .error(function(){
             console.log('error!');
+            deferred.reject();
           });
 
-        // Attempting to use promises
-        if (authData.uid) {
-          deferred.resolve(authData.uid);
-        } else {
-          deferred.reject('woops!');
-        }
       });
     });
 


### PR DESCRIPTION
This pull request uses the Facebook Friends API to populate the list of people they can potentially send a snapcache to.

One limitation (although it is probably the behavior we want), is that the Facebook Friends API will only give you a list of friends that have already downloaded and performed authentication in the app.

Closes #58.
