### PR TITLE
(feat) Throttle geocoding requests, store human-readable location in firebase on cache creation

### DIFF
--- a/www/js/create/CreateCtrl.js
+++ b/www/js/create/CreateCtrl.js
@@ -40,6 +40,8 @@ angular.module('snapcache.create', [])
       latitude: userSession.position.coords.latitude,
       longitude: userSession.position.coords.longitude
     };
+    // Store human-readable location in database
+    self.properties.readable_location = userSession.readable_location;
 
     Caches.create(self.properties);
   };

--- a/www/js/sidemenu/MenuCtrl.js
+++ b/www/js/sidemenu/MenuCtrl.js
@@ -31,8 +31,11 @@ angular.module('snapcache.menu', [])
       userSession.position = pos;
       self.position = pos;
       console.log(userSession.uid);
-      // get human-readable location (address)
-      // self.getAddress();
+      // get human-readable location (address), throttled
+      // to 1 request per 20 seconds
+      if (Date.now() > self.geocodingTimeout) {
+        self.getAddress();
+      }
       Geofire.geofire.set(userSession.uid, [
         pos.coords.latitude,
         pos.coords.longitude
@@ -53,10 +56,13 @@ angular.module('snapcache.menu', [])
     Geofire.geofire.remove(userSession.uid);
   });
 
+  // Timeout used to throttle geocoding requests
+  self.geocodingTimeout = Date.now();
+
   // Get reverse geocoding from lat/lng coords for
   // human-readable location
   self.getAddress = function() {
-    // do geocoding here...
+    console.log('Requesting human-readable location');
     var geocoder = new google.maps.Geocoder();
     var lat = userSession.position.coords.latitude;
     var lng = userSession.position.coords.longitude;
@@ -64,13 +70,19 @@ angular.module('snapcache.menu', [])
     // request reverse geocode from geocoder
     geocoder.geocode({'latLng': latlng}, function(results, status) {
       if (status == google.maps.GeocoderStatus.OK) {
+        self.geocodingTimeout = Date.now() + 20000;
         if (results[0]) {
           // store the human-readable
           self.readable_location = results[0].formatted_address;
+          userSession.readable_location = self.readable_location;
         } else {
           console.log('No human-readable location found');
         }
       } else {
+        // If we receive an error status, delay future geocoding request
+        self.geocodingTimeout = Date.now() + 40000;
+        self.readable_location = undefined;
+        userSession.readable_location = undefined;
         alert('Geocoder failed due to: ' + status);
       }
     });


### PR DESCRIPTION
Geocoding requests are throttled to 1 request per 20 seconds, are paused when app
is sent to the background, and resume on return to foreground.

The results of the reverse geocoding requests (human-readable locations) are stored in
firebase as a property on newly-created caches.

close #65 close #71 
