### PR TITLE
(feat) Sort outbox caches by expiresAt

### DIFF
--- a/www/js/outbox/OutboxCtrl.js
+++ b/www/js/outbox/OutboxCtrl.js
@@ -3,7 +3,7 @@ angular.module('snapcache.outbox', [])
 
 .controller('OutboxCtrl', function (Caches) {
   var self = this;
-  self.caches = {};
+  self.caches = [];
 
   self.displayCaches = function () {
     Caches.getContributable().then(
@@ -13,7 +13,7 @@ angular.module('snapcache.outbox', [])
           (function (cacheID) {
             Caches.getCacheDetails(cacheID).then(
               function (cache) {
-                self.caches[cacheID] = cache;
+                self.caches.push(cache);
               });
           })(key);
         }

--- a/www/js/outbox/outbox.html
+++ b/www/js/outbox/outbox.html
@@ -6,7 +6,7 @@
   <ion-content>
   
     <ion-list type="card">
-      <ion-item ng-repeat="cache in outctrl.caches" ng-click="outctrl.displayDetails(cache)">
+      <ion-item ng-repeat="cache in outctrl.caches | orderBy: 'expiresAt'" ng-click="outctrl.displayDetails(cache)">
         <span class="cache-title">{{ cache.title }}</span>
         <div class="cache-countdown">{{ cache.expiresAt | countdown }}</div>
         <div class="cache-location">{{ cache.coordinates }}</div>


### PR DESCRIPTION
This changes the cache property on the controller to be an array instead of an object, because Angular has issues doing orderBy over objects.
