### PR TITLE
(refactor) Set default drop date to today and move drop time into own row

### DIFF
--- a/www/js/create/CreateCtrl.js
+++ b/www/js/create/CreateCtrl.js
@@ -46,6 +46,10 @@ angular.module('snapcache.create', [])
 
   var self = this;
   self.properties = {};
+  self.datetime = {};
+
+  // Set default for the initial drop date
+  self.datetime.dropdate = new Date();
 
   // Set sane defaults for slider values (1 hour)
   self.window_slider = 40710;

--- a/www/js/create/CreateCtrl.js
+++ b/www/js/create/CreateCtrl.js
@@ -39,7 +39,7 @@ angular.module('snapcache.create', [])
     } else {
       return 86400000 * value;
     }
-  }
+  };
 })
 
 .controller('CreateCtrl', function($filter, $scope, $ionicModal, $timeout, Caches, UserFriends, userSession) {

--- a/www/js/create/create.html
+++ b/www/js/create/create.html
@@ -37,7 +37,11 @@
         <label class="item item-input item-stacked-label">
           <span class="input-label">Drop Date</span>
           <input type="date" value="{{createCtrl.datetime.dropdate}}" ng-model="createCtrl.datetime.dropdate" required>
-          <input type="time" ng-if="createCtrl.datetime.dropdate" ng-change="createCtrl.convertDateTime()" value="{{createCtrl.datetime.droptime}}" ng-model="createCtrl.datetime.droptime" required>
+        </label>
+
+        <label class="item item-input item-stacked-label" ng-if="createCtrl.datetime.dropdate">
+          <span class="input-label">Drop Time</span>
+          <input type="time" ng-change="createCtrl.convertDateTime()" value="{{createCtrl.datetime.droptime}}" ng-model="createCtrl.datetime.droptime" required>
         </label>
 
         <label class="item ">


### PR DESCRIPTION
We were having an issue on mobile where we were unable to use the time picker. I think that might have been because dropdate and droptime were in the same row. This request moves drop time into its own row (although it automatically hides if the user does not have a drop date.
