### PR TITLE
(feat) Allow user to place marker on map to drop cache at specific location

### DIFF
--- a/www/js/create/CreateCtrl.js
+++ b/www/js/create/CreateCtrl.js
@@ -206,34 +206,29 @@ angular.module('snapcache.create', [])
 
     self.map = map;
 
-    var search = new google.maps.places.SearchBox(document.getElementById("map-search"), {});
-    google.maps.event.addListener(search, 'places_changed', function() {
-      var places = search.getPlaces();
-      console.log("places changed:", places);
-      self.properties.coordinates = {
-        latitude: places[0].geometry.location.k,
-        longitude: places[0].geometry.location.D
-      };
+    // Add event listener for mousedown event
+    google.maps.event.addListener(self.map, 'mousedown', function(event){
+      console.log('detected a mouse down event!');
+
+      // If the user has not already initiated a mousedown event, create
+      // a function that will run in 1 second, placing the marker at the
+      // desired location. This is done so that the user will have to do a
+      // long click in order to place a marker somewhere.
+      if (angular.isUndefined(self.placeMarkerPromise)) {
+        self.placeMarkerPromise = $timeout(function() {
+          console.log('marker placed at', event.latLng);
+        }, 1000);
+      }
+    });
+
+    // Add event listener for mouseup event
+    google.maps.event.addListener(self.map, 'mouseup', function(){
+      console.log('detected a mouse up event');
+    });
+
+    // Add event listener for dragstart event
+    google.maps.event.addListener(self.map, 'dragstart', function(){
+      console.log('detected a drag event');
     });
   };
-
-  // Not used at the moment, potential fix for map search box issue
-  self.update = function() {
-    $timeout(function() {
-      var container = document.querySelector('.pac-container');
-      container.setAttribute('data-tap-disabled', 'true');
-      container.onclick = function() {
-        document.getElementById('autocomplete').blur();
-      }
-      var placeNodes = document.querySelectorAll('.pac-item');
-      console.log('place nodes:', placeNodes);
-      for(var i = 0; i < placeNodes.length; i++) {
-        console.log(placeNodes[i]);
-        placeNodes[i].addEventListener('click', function() {
-          console.log('clicked');
-        });
-      }
-    }, 400);
-  };
-
 });

--- a/www/js/create/CreateCtrl.js
+++ b/www/js/create/CreateCtrl.js
@@ -145,10 +145,10 @@ angular.module('snapcache.create', [])
     self.properties.contributors = {};
     self.properties.contributors[userSession.uid] = true;
     // Set cache location as property to be stored
-    self.properties.coordinates = {
-      latitude: userSession.position.coords.latitude,
-      longitude: userSession.position.coords.longitude
-    };
+    // self.properties.coordinates = {
+    //   latitude: userSession.position.coords.latitude,
+    //   longitude: userSession.position.coords.longitude
+    // };
     // Store human-readable location in database
     self.properties.readable_location = userSession.readable_location;
     // get milliseconds for time range sliders
@@ -248,10 +248,13 @@ angular.module('snapcache.create', [])
 
     // Updating any data that the scope needs to know about due to the
     // fact we are doing this from within an asynchronous call.
-    // $scope.$apply(function() {
-    //   self.markerPosition = latLng.toString();
-    //   console.log('the markers pos is:', self.markerPosition);
-    // });
+    $scope.$apply(function() {
+      self.properties.coordinates = {
+        latitude: latLng.k,
+        longitude: latLng.D
+      };
+      console.log('the markers pos is:', self.properties.coordinates);
+    });
   };
 
   // `placeMarkerCancel()` will remove the function that is scheduled to

--- a/www/js/create/create.html
+++ b/www/js/create/create.html
@@ -2,8 +2,7 @@
   <ion-header-bar>
     <h1 class="title">New Snapcache</h1>
     <div class="bar bar-header">
-      <!-- Button commented out for now since map isn't fully functional -->
-      <!-- <button class="button button-clear icon ion-map" ng-click="createCtrl.showMap()"></button> -->
+      <button class="button button-clear icon ion-map" ng-click="createCtrl.showMap()"></button>
       <h1 class="title">New Snapcache</h1>
       <button class="button button-clear" ng-click="menuCtrl.closeCreate()">Close</button>
     </div>

--- a/www/js/create/map.html
+++ b/www/js/create/map.html
@@ -6,9 +6,6 @@
     </div>
   </ion-header-bar>
   <ion-content>
-    <label class="item item-input">
-      <input id="map-search" type="text" placeholder='Search' ng-change='createCtrl.update()' ng-model='mapCtrl.search'>
-    </label>
     <div id="map" data-tap-disabled="true"></div>
   </ion-content>
 </ion-modal-view>


### PR DESCRIPTION
This pull request removes the search bar, and instead allows the user to do a long press at a specific location. It will ignore drag events, and short taps in order to not confuse the user's intention.

Next steps could involve moving the radius slider to the map modal, and plotting a circle around the user's specified cache location so they know what the radius actually corresponds to.

Closes #41 
