### PR TITLE
(fix) Cause mapModal to be removed when cache created/closed

### DIFF
--- a/www/js/create/CreateCtrl.js
+++ b/www/js/create/CreateCtrl.js
@@ -167,6 +167,15 @@ angular.module('snapcache.create', [])
     self.mapModal = modal;
   });
 
+  // Create an event listener that will remove the map modal whenever
+  // the user creates or closes the Create Cache view.
+  //
+  // NOTE: It must be done this way since the closing of the Create Cache view
+  // occurs in a parent scope, which has no knowledge of the mapModal.
+  $scope.$on('closeCreate', function(){
+    self.mapModal.remove();
+  });
+
   // Triggered in the map modal to close it
   self.closeMap = function() {
     self.render = false;

--- a/www/js/sidemenu/MenuCtrl.js
+++ b/www/js/sidemenu/MenuCtrl.js
@@ -9,6 +9,10 @@ angular.module('snapcache.menu', [])
   // Triggered in the create modal to close it
   self.closeCreate = function() {
     self.createModal.remove();
+    // Broadcast an event to the child scope so that it knows to remove
+    // the mapModal (this fixes a bug where the map would not appear since it
+    // was not properly removed.
+    $scope.$broadcast('closeCreate');
   };
 
   // Open the create modal


### PR DESCRIPTION
This fixes #133 where the map modal would not show a map after a single cache was created due the mapModal not being removed.

To fix, we use $broadcast and $on to listen to events (allowing for communication from the parent scope to the child scope).
