### PR TITLE
(feat) Allow for multiple contributions to a cache

### DIFF
--- a/www/js/detail/InboxDetailCtrl.js
+++ b/www/js/detail/InboxDetailCtrl.js
@@ -5,11 +5,11 @@ angular.module('snapcache.detail.inbox', [])
 .controller('InboxDetailCtrl', function (userSession) {
   var self = this;
   self.cache = userSession.currentCache;
-  self.texts = [];
+  self.items = [];
 
-  // Load the cache's text objects into an array
-  var texts = self.cache.contents.text;
-  for (var id in texts) {
-    self.texts.push(texts[id]);
+  // Load the cache's objects into an array
+  var items = self.cache.contents;
+  for (var id in items) {
+    self.items.push(items[id]);
   }
 });

--- a/www/js/detail/InboxDetailCtrl.js
+++ b/www/js/detail/InboxDetailCtrl.js
@@ -5,4 +5,11 @@ angular.module('snapcache.detail.inbox', [])
 .controller('InboxDetailCtrl', function (userSession) {
   var self = this;
   self.cache = userSession.currentCache;
+  self.texts = [];
+
+  // Load the cache's text objects into an array
+  var texts = self.cache.contents.text;
+  for (var id in texts) {
+    self.texts.push(texts[id]);
+  }
 });

--- a/www/js/detail/OutboxDetailCtrl.js
+++ b/www/js/detail/OutboxDetailCtrl.js
@@ -40,5 +40,8 @@ angular.module('snapcache.detail.outbox', [])
 
     // Send the additional cache contribution to Firebase.
     Caches.addContribution(self.cache._id, "text", text);
+
+    // Remove the user input
+    self.text = '';
   };
 });

--- a/www/js/detail/OutboxDetailCtrl.js
+++ b/www/js/detail/OutboxDetailCtrl.js
@@ -21,11 +21,18 @@ angular.module('snapcache.detail.outbox', [])
   }
 
   self.addText = function(text) {
-    // Push the added message into the texts array so that the view
-    // dynamically updates.
-    self.texts.push({
+    var text = {
       message: text,
       contributor: userSession.name
-    });
+    };
+    // Push the added message into the texts array so that the view
+    // dynamically updates.
+    self.texts.push(text);
+
+    // Need to also add it to the cache, so that the view will remain consistent
+    // as the user switches in and out of the outbox detail.
+      // NOTE: We just use a random id to replicate the structure that Firebase
+      // uses. This should be fine for the case where the user logs in.
+    self.cache.contents.text[Math.random()] = text;
   };
 });

--- a/www/js/detail/OutboxDetailCtrl.js
+++ b/www/js/detail/OutboxDetailCtrl.js
@@ -6,6 +6,7 @@ angular.module('snapcache.detail.outbox', [])
   var self = this;
   self.cache = userSession.currentCache;
   self.texts = [];
+  self.isContributable = (Date.now() < self.cache.droptime);
 
   // Load the cache's text objects into an array
   // NOTE: Currently, the assumed object structure is the following:
@@ -39,6 +40,5 @@ angular.module('snapcache.detail.outbox', [])
 
     // Send the additional cache contribution to Firebase.
     Caches.addContribution(self.cache._id, "text", text);
-
   };
 });

--- a/www/js/detail/OutboxDetailCtrl.js
+++ b/www/js/detail/OutboxDetailCtrl.js
@@ -5,4 +5,19 @@ angular.module('snapcache.detail.outbox', [])
 .controller('OutboxDetailCtrl', function (userSession) {
   var self = this;
   self.cache = userSession.currentCache;
+  self.texts = [];
+
+  // Load the cache's text objects into an array
+  // NOTE: Currently, the assumed object structure is the following:
+  //  - CacheID
+  //    - contents
+  //      - text
+  //        - ContributionID
+  //          - contributor
+  //          - message
+  var texts = self.cache.contents.text;
+  for (var id in texts) {
+    self.texts.push(texts[id]);
+  }
+
 });

--- a/www/js/detail/OutboxDetailCtrl.js
+++ b/www/js/detail/OutboxDetailCtrl.js
@@ -2,7 +2,7 @@
 angular.module('snapcache.detail.outbox', [])
 
 // Detail controller
-.controller('OutboxDetailCtrl', function (userSession) {
+.controller('OutboxDetailCtrl', function (userSession, Caches) {
   var self = this;
   self.cache = userSession.currentCache;
   self.texts = [];
@@ -20,6 +20,8 @@ angular.module('snapcache.detail.outbox', [])
     self.texts.push(texts[id]);
   }
 
+  // `addText()` will take the text of an additional message that the user
+  // wants to contribute to the cache, add it, and save it to Firebase.
   self.addText = function(text) {
     var text = {
       message: text,
@@ -34,5 +36,9 @@ angular.module('snapcache.detail.outbox', [])
       // NOTE: We just use a random id to replicate the structure that Firebase
       // uses. This should be fine for the case where the user logs in.
     self.cache.contents.text[Math.random()] = text;
+
+    // Send the additional cache contribution to Firebase.
+    Caches.addContribution(self.cache._id, "text", text);
+
   };
 });

--- a/www/js/detail/OutboxDetailCtrl.js
+++ b/www/js/detail/OutboxDetailCtrl.js
@@ -20,4 +20,12 @@ angular.module('snapcache.detail.outbox', [])
     self.texts.push(texts[id]);
   }
 
+  self.addText = function(text) {
+    // Push the added message into the texts array so that the view
+    // dynamically updates.
+    self.texts.push({
+      message: text,
+      contributor: 'FILL IN WITH ACTUAL NAME'
+    });
+  };
 });

--- a/www/js/detail/OutboxDetailCtrl.js
+++ b/www/js/detail/OutboxDetailCtrl.js
@@ -25,7 +25,7 @@ angular.module('snapcache.detail.outbox', [])
     // dynamically updates.
     self.texts.push({
       message: text,
-      contributor: 'FILL IN WITH ACTUAL NAME'
+      contributor: userSession.name
     });
   };
 });

--- a/www/js/detail/OutboxDetailCtrl.js
+++ b/www/js/detail/OutboxDetailCtrl.js
@@ -5,41 +5,45 @@ angular.module('snapcache.detail.outbox', [])
 .controller('OutboxDetailCtrl', function (userSession, Caches) {
   var self = this;
   self.cache = userSession.currentCache;
-  self.texts = [];
+  self.items = [];
   self.isContributable = (Date.now() < self.cache.droptime);
 
-  // Load the cache's text objects into an array
+  // Load the cache's objects into an array
   // NOTE: Currently, the assumed object structure is the following:
   //  - CacheID
   //    - contents
-  //      - text
   //        - ContributionID
   //          - contributor
-  //          - message
-  var texts = self.cache.contents.text;
-  for (var id in texts) {
-    self.texts.push(texts[id]);
+  //          - content
+  //            - type
+  //            - value specific to type
+  var items = self.cache.contents;
+  for (var id in items) {
+    self.items.push(items[id]);
   }
 
   // `addText()` will take the text of an additional message that the user
   // wants to contribute to the cache, add it, and save it to Firebase.
   self.addText = function(text) {
-    var text = {
-      message: text,
-      contributor: userSession.name
+    var contribution = {
+      contributor: userSession.name,
+      content: {
+        type: "text",
+        message: text
+      }
     };
     // Push the added message into the texts array so that the view
     // dynamically updates.
-    self.texts.push(text);
+    self.items.push(contribution);
 
     // Need to also add it to the cache, so that the view will remain consistent
     // as the user switches in and out of the outbox detail.
       // NOTE: We just use a random id to replicate the structure that Firebase
       // uses. This should be fine for the case where the user logs in.
-    self.cache.contents.text[Math.random()] = text;
+    self.cache.contents[Math.random()] = contribution;
 
     // Send the additional cache contribution to Firebase.
-    Caches.addContribution(self.cache._id, "text", text);
+    Caches.addContribution(self.cache._id, contribution);
 
     // Remove the user input
     self.text = '';

--- a/www/js/detail/inboxDetail.html
+++ b/www/js/detail/inboxDetail.html
@@ -9,9 +9,10 @@
   </ion-header-bar>
   <ion-content>
     <ion-list type="card">
-      <ion-item ng-repeat="text in dctrl.texts">
-        <span class="bold-text">{{ text.contributor }}</span> said "{{ text.message }}"
+      <ion-item ng-repeat="item in dctrl.items">
+        <span class="bold-text">{{ item.contributor }}</span> said "{{ item.content.message }}"
       </ion-item>
+    </ion-list>
     </ion-list>
   </ion-content>
 </ion-modal-view>

--- a/www/js/detail/inboxDetail.html
+++ b/www/js/detail/inboxDetail.html
@@ -8,9 +8,10 @@
 
   </ion-header-bar>
   <ion-content>
-    <div class="detail-message">{{ dctrl.cache.message }}</div>
-    <div class="detail-countdown" am-time-ago="{{ dctrl.cache.expiresAt }}"></div>
-    <div class="detail-location">{{ dctrl.cache.readable_location }}</div>
-
+    <ion-list type="card">
+      <ion-item ng-repeat="text in dctrl.texts">
+        <span class="bold-text">{{ text.contributor }}</span> said "{{ text.message }}"
+      </ion-item>
+    </ion-list>
   </ion-content>
 </ion-modal-view>

--- a/www/js/detail/outboxDetail.html
+++ b/www/js/detail/outboxDetail.html
@@ -16,11 +16,20 @@
 
   <div class="bar bar-footer item-input-inset">
     <!-- <button class="button icon ion-paperclip"></button> -->
-    <label class="item-input-wrapper">
-      <i class="icon ion-ios7-search placeholder-icon"></i>
-      <input type="text" placeholder="Message" ng-model="text">
-    </label>
-    <button class="button icon ion-paper-airplane" ng-click="dctrl.addText(text)"></button>
+      <label class="item-input-wrapper" ng-show="dctrl.isContributable">
+        <i class="icon ion-ios7-search placeholder-icon"></i>
+        <input type="text" placeholder="Message" ng-model="text">
+      </label>
+      <button class="button icon ion-paper-airplane" ng-click="dctrl.addText(text)" ng-show="dctrl.isContributable"></button>
+
+    <div ng-show="!dctrl.isContributable">
+      <div ng-show="dctrl.cache.discovered">
+        The cache has been discovered!
+      </div>
+      <div ng-show="!dctrl.cache.discovered">
+        The cache is available, but has not been discovered.
+      </div>
+    </div>
   </div>
 
 </ion-modal-view>

--- a/www/js/detail/outboxDetail.html
+++ b/www/js/detail/outboxDetail.html
@@ -18,9 +18,9 @@
     <!-- <button class="button icon ion-paperclip"></button> -->
     <label class="item-input-wrapper">
       <i class="icon ion-ios7-search placeholder-icon"></i>
-      <input type="text" placeholder="Message">
+      <input type="text" placeholder="Message" ng-model="text">
     </label>
-    <button class="button icon ion-paper-airplane"></button>
+    <button class="button icon ion-paper-airplane" ng-click="dctrl.addText(text)"></button>
   </div>
 
 </ion-modal-view>

--- a/www/js/detail/outboxDetail.html
+++ b/www/js/detail/outboxDetail.html
@@ -5,12 +5,12 @@
       <h1 class="title">{{ dctrl.cache.title }}</h1>
       <button class="button button-clear" ng-click="outctrl.closeDetail()">Close</button>
     </div>
-
   </ion-header-bar>
   <ion-content>
-    <div class="detail-message">{{ dctrl.cache.message }}</div>
-    <div class="detail-countdown" am-time-ago="{{ dctrl.cache.expiresAt }}"></div>
-    <div class="detail-location">{{ dctrl.cache.readable_location }}</div>
-
+    <ion-list type="card">
+      <ion-item ng-repeat="text in dctrl.texts">
+        <span class="bold-text">{{ text.contributor }}</span> said "{{ text.message }}"
+      </ion-item>
+    </ion-list>
   </ion-content>
 </ion-modal-view>

--- a/www/js/detail/outboxDetail.html
+++ b/www/js/detail/outboxDetail.html
@@ -18,9 +18,9 @@
     <!-- <button class="button icon ion-paperclip"></button> -->
       <label class="item-input-wrapper" ng-show="dctrl.isContributable">
         <i class="icon ion-ios7-search placeholder-icon"></i>
-        <input type="text" placeholder="Message" ng-model="text">
+        <input type="text" placeholder="Message" ng-model="dctrl.text">
       </label>
-      <button class="button icon ion-paper-airplane" ng-click="dctrl.addText(text)" ng-show="dctrl.isContributable"></button>
+      <button class="button icon ion-paper-airplane" ng-click="dctrl.addText(dctrl.text)" ng-show="dctrl.isContributable"></button>
 
     <div ng-show="!dctrl.isContributable">
       <div ng-show="dctrl.cache.discovered">

--- a/www/js/detail/outboxDetail.html
+++ b/www/js/detail/outboxDetail.html
@@ -13,4 +13,14 @@
       </ion-item>
     </ion-list>
   </ion-content>
+
+  <div class="bar bar-footer item-input-inset">
+    <!-- <button class="button icon ion-paperclip"></button> -->
+    <label class="item-input-wrapper">
+      <i class="icon ion-ios7-search placeholder-icon"></i>
+      <input type="text" placeholder="Message">
+    </label>
+    <button class="button icon ion-paper-airplane"></button>
+  </div>
+
 </ion-modal-view>

--- a/www/js/detail/outboxDetail.html
+++ b/www/js/detail/outboxDetail.html
@@ -8,8 +8,8 @@
   </ion-header-bar>
   <ion-content>
     <ion-list type="card">
-      <ion-item ng-repeat="text in dctrl.texts">
-        <span class="bold-text">{{ text.contributor }}</span> said "{{ text.message }}"
+      <ion-item ng-repeat="item in dctrl.items">
+        <span class="bold-text">{{ item.contributor }}</span> said "{{ item.content.message }}"
       </ion-item>
     </ion-list>
   </ion-content>

--- a/www/js/shared/CachesService.js
+++ b/www/js/shared/CachesService.js
@@ -129,8 +129,15 @@ angular.module('snapcache.services.caches', [])
   // (contributors and recipients).
   function create(cacheParams) {
     var newCacheRef = cachesRef.push(cacheParams);
-    // Get the ID that Firebase will safe the cache at.
+    // Get the ID that Firebase will save the cache at.
     var cacheID = newCacheRef.key();
+
+    // Get the message and add it is the first contribution
+    var text = {
+      message: cacheParams.message,
+      contributor: userSession.name
+    };
+    addContribution(cacheID, "text", text);
 
     // Add the new cache's id to the contributing users inboxes.
     var contributors = cacheParams.contributors;

--- a/www/js/shared/CachesService.js
+++ b/www/js/shared/CachesService.js
@@ -14,6 +14,7 @@ angular.module('snapcache.services.caches', [])
     getCacheDetailsForDiscovered: getCacheDetailsForDiscovered,
     onCacheDiscovered: onCacheDiscovered,
     create: create,
+    addContribution: addContribution,
     discoverCache: discoverCache,
     removeCache: removeCache
   };
@@ -146,6 +147,18 @@ angular.module('snapcache.services.caches', [])
       cache[cacheID] = true;
       usersRef.child(userID).child('receivedCaches').update(cache);
     }
+  }
+  // `addContribution()` is used to add additional data to a cache based
+  // on the `type` property.
+  function addContribution(cacheID, type, contents) {
+    var contentsRef = cachesRef.child(cacheID).child('contents');
+    contentsRef.child(type).push(contents);
+    //  NOTE: The object structure is the following:
+    //  - CacheID
+    //    - contents
+    //      - type
+    //        - ContributionID
+    //          - contents
   }
 
   // Toggles the discover flag on the indicated cache (in Firebase) and will

--- a/www/js/shared/CachesService.js
+++ b/www/js/shared/CachesService.js
@@ -134,10 +134,13 @@ angular.module('snapcache.services.caches', [])
 
     // Get the message and add it is the first contribution
     var text = {
-      message: cacheParams.message,
-      contributor: userSession.name
+      contributor: userSession.name,
+      content: {
+        type: "text",
+        message: cacheParams.message
+      }
     };
-    addContribution(cacheID, "text", text);
+    addContribution(cacheID, text);
 
     // Add the new cache's id to the contributing users inboxes.
     var contributors = cacheParams.contributors;
@@ -157,15 +160,17 @@ angular.module('snapcache.services.caches', [])
   }
   // `addContribution()` is used to add additional data to a cache based
   // on the `type` property.
-  function addContribution(cacheID, type, contents) {
+  function addContribution(cacheID, contribution) {
     var contentsRef = cachesRef.child(cacheID).child('contents');
-    contentsRef.child(type).push(contents);
+    contentsRef.push(contribution);
     //  NOTE: The object structure is the following:
     //  - CacheID
     //    - contents
-    //      - type
     //        - ContributionID
-    //          - contents
+    //          - contributor
+    //          - content
+    //            - type
+    //            - value specific to type
   }
 
   // Toggles the discover flag on the indicated cache (in Firebase) and will

--- a/www/js/shared/FirebaseAuthService.js
+++ b/www/js/shared/FirebaseAuthService.js
@@ -37,6 +37,7 @@ angular.module('snapcache.services.auth', [])
       usersRef.child(authData.uid).once('value', function(snapshot){
         // Storing certain information on userSession for access anywhere in app.
         userSession.uid = authData.uid;
+        userSession.name = authData.facebook.displayName;
 
         // No matter if the user is new or existing, we just need to update
         // their data property (if they are new, their entire tree will be created).


### PR DESCRIPTION
This pull request allows a user to contribute to a cache multiple times, up to the point that the cache becomes discoverable.

The key change is how the contents are modeled in Firebase. Now we are using the parameter `contents`, which stores `contributionID`s, for the following structure
- contents
  - cacheID
    - contributor
    -  content
      - type
      - type-specific content
