### PR TITLE
(fix) Add contributor to userSession upon mobile login

### DIFF
--- a/www/js/shared/FirebaseAuthService.js
+++ b/www/js/shared/FirebaseAuthService.js
@@ -72,6 +72,8 @@ angular.module('snapcache.services.auth', [])
     return deferred.promise;
   }
 
+  // TODO: Refactor since the code in this function is almost identical
+  // to the code in the above function.
   function nativeLogin() {
     var deferred = $q.defer();
     facebookConnectPlugin.login(['email', 'user_friends'], function(status) {
@@ -88,6 +90,7 @@ angular.module('snapcache.services.auth', [])
             usersRef.child(authData.uid).once('value', function(snapshot){
               // Storing certain information on userSession for access anywhere in app.
               userSession.uid = authData.uid;
+              userSession.name = authData.facebook.displayName;
 
               // No matter if the user is new or existing, we just need to update
               // their data property (if they are new, their entire tree will be created).


### PR DESCRIPTION
I forgot to add a line of code that would add the contributor to the userSession object on mobile login. This caused the user to be unable to send a cache from mobile since the contributor was not being set on the object sent to Firebase.
