### PR TITLE
(fix) Use local copy of GeoFire rather than retrieving from CDN

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -22,7 +22,7 @@
     <!-- additional dependencies -->
     <script src="lib/rsvp/rsvp.min.js"></script>
     <script src="lib/firebase/firebase.js"></script>
-    <script src="https://cdn.firebase.com/libs/geofire/2.0.0/geofire.min.js"></script>
+    <script src="lib/geofire/dist/geofire.min.js"></script>
     <script src="lib/angularfire/dist/angularfire.min.js"></script>
 
     <!-- your app's js -->


### PR DESCRIPTION
Was causing Firebase to run rampant with console warnings.
