### PR TITLE
(fix) Update the readable location on map pin placement

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -39,6 +39,7 @@
     <script src="js/shared/CachesService.js"></script>
     <script src="js/shared/GeofireService.js"></script>
     <script src="js/shared/UserFriendsService.js"></script>
+    <script src="js/shared/LocationService.js"></script>
   </head>
 
   <body ng-app="snapcache">

--- a/www/js/create/CreateCtrl.js
+++ b/www/js/create/CreateCtrl.js
@@ -102,6 +102,12 @@ angular.module('snapcache.create', [])
   // Cache will have the `discovered` property set to false
   self.properties.discovered = false;
 
+  // Want to use the user's current location as the default location
+  self.properties.coordinates = {
+    latitude: userSession.position.coords.latitude,
+    longitude: userSession.position.coords.longitude
+  };
+
   // `convertDateTime()` will take the user provided input and convert it to
   // milliseconds. To do this, it also has to know what date the user selected.
   // Only once the user has selected a date does the time box open up.

--- a/www/js/create/CreateCtrl.js
+++ b/www/js/create/CreateCtrl.js
@@ -76,7 +76,7 @@ angular.module('snapcache.create', [])
   };
 })
 
-.controller('CreateCtrl', function($filter, $scope, $ionicModal, $timeout, Caches, UserFriends, userSession, $ionicPopover) {
+.controller('CreateCtrl', function($filter, $scope, $ionicModal, $timeout, Caches, UserFriends, userSession, $ionicPopover, Location) {
 
   var self = this;
   self.properties = {};
@@ -274,6 +274,12 @@ angular.module('snapcache.create', [])
       };
       console.log('the markers pos is:', self.properties.coordinates);
     });
+
+    // Emitting an event so that the parent controller (menuCtrl) can
+    // change the `readable_location` and position `parameters`.
+    Location.getAddress(latLng.k, latLng.D).then(function(addr){
+      $scope.$emit('pinPlaced', addr);
+    });
   };
 
   // `placeMarkerCancel()` will remove the function that is scheduled to
@@ -312,7 +318,7 @@ angular.module('snapcache.create', [])
     console.log('showing popover');
     self.popover.show($event);
   };
-  
+
   self.closePopover = function() {
     self.popover.hide();
   };

--- a/www/js/shared/LocationService.js
+++ b/www/js/shared/LocationService.js
@@ -1,0 +1,16 @@
+// Location is a factory that gives functionality associated with getting
+// a users caches (but contributable and received ones), and creating
+// new ones.
+angular.module('snapcache.services.location', [])
+
+.factory('Location', function(){
+
+  return {
+    getAddress: getAddress
+  };
+
+  function getAddress(lat, lon) {
+    return 'yay it is working!';
+  }
+
+});

--- a/www/js/shared/LocationService.js
+++ b/www/js/shared/LocationService.js
@@ -3,14 +3,40 @@
 // new ones.
 angular.module('snapcache.services.location', [])
 
-.factory('Location', function(){
+.factory('Location', function($q){
 
   return {
     getAddress: getAddress
   };
 
+  // `getAddress()` takes a latitude and longitude and will use the Google
+  // Maps API in order to identify the human-readable location associated
+  // with that position.
   function getAddress(lat, lon) {
-    return 'yay it is working!';
-  }
+    // Setting up a promise since the call to Google Maps API will be
+    // asynchronous.
+    var deferred = $q.defer();
 
+    console.log('Requesting human-readable location');
+    var geocoder = new google.maps.Geocoder();
+    var latlng = new google.maps.LatLng(lat, lon);
+
+    // Request reverse geocode from geocoder
+    geocoder.geocode({'latLng': latlng}, function(results, status) {
+      if (status == google.maps.GeocoderStatus.OK) {
+        // self.geocodingTimeout = Date.now() + 20000;
+        if (results[0]) {
+          // store the human-readable
+          deferred.resolve(results[0].formatted_address);
+        } else {
+          deferred.resolve("Unknown");
+        }
+      } else {
+        deferred.reject('Error in reverse geocoding');
+      }
+    });
+
+    // Return the promise associated with the API call.
+    return deferred.promise;
+  }
 });

--- a/www/js/sidemenu/MenuCtrl.js
+++ b/www/js/sidemenu/MenuCtrl.js
@@ -1,7 +1,7 @@
 // Menu Controller
 angular.module('snapcache.menu', [])
 
-.controller('MenuCtrl', function(FIREBASE_REF, Caches, $scope, $ionicModal, $ionicPlatform, userSession, Geofire) {
+.controller('MenuCtrl', function(FIREBASE_REF, Caches, $scope, $ionicModal, $ionicPlatform, userSession, Geofire, Location) {
 
   var self = this;
   self.position;
@@ -128,12 +128,7 @@ angular.module('snapcache.menu', [])
       console.log('current position:', pos);
       userSession.position = pos;
       self.position = pos;
-      console.log(userSession.uid);
-      // get human-readable location (address), throttled to 1
-      // request per 20 seconds and only runs app when in foreground
-      if (inForeground && Date.now() > self.geocodingTimeout) {
-        self.getAddress();
-      }
+
       // remove key in order to satisfy the 'key entered' event
       // (when key already inside radius)
       Geofire.geofire.remove(userSession.uid);
@@ -157,37 +152,4 @@ angular.module('snapcache.menu', [])
     // remove user from geofire
     Geofire.geofire.remove(userSession.uid);
   };
-
-  // Timeout used to throttle geocoding requests
-  self.geocodingTimeout = Date.now();
-
-  // Get reverse geocoding from lat/lng coords for
-  // human-readable location
-  self.getAddress = function() {
-    console.log('Requesting human-readable location');
-    var geocoder = new google.maps.Geocoder();
-    var lat = userSession.position.coords.latitude;
-    var lng = userSession.position.coords.longitude;
-    var latlng = new google.maps.LatLng(lat, lng);
-    // request reverse geocode from geocoder
-    geocoder.geocode({'latLng': latlng}, function(results, status) {
-      if (status == google.maps.GeocoderStatus.OK) {
-        self.geocodingTimeout = Date.now() + 20000;
-        if (results[0]) {
-          // store the human-readable
-          self.readable_location = results[0].formatted_address;
-          userSession.readable_location = self.readable_location;
-        } else {
-          console.log('No human-readable location found');
-        }
-      } else {
-        // If we receive an error status, delay future geocoding request
-        self.geocodingTimeout = Date.now() + 40000;
-        self.readable_location = undefined;
-        userSession.readable_location = undefined;
-        alert('Geocoder failed due to: ' + status);
-      }
-    });
-  };
-
 });

--- a/www/js/sidemenu/MenuCtrl.js
+++ b/www/js/sidemenu/MenuCtrl.js
@@ -172,7 +172,7 @@ angular.module('snapcache.menu', [])
 
   // Listen for `pinPlaced` events so that we know we can set the
   // new address in order to update the view.
-  $scope.$on('pinPlaced', function(event, addr){=
+  $scope.$on('pinPlaced', function(event, addr){
     self.readable_location = addr;
     userSession.readable_location = addr;
   });

--- a/www/js/sidemenu/MenuCtrl.js
+++ b/www/js/sidemenu/MenuCtrl.js
@@ -170,4 +170,10 @@ angular.module('snapcache.menu', [])
     userSession.position = pos;
   });
 
+  // Listen for `pinPlaced` events so that we know we can set the
+  // new address in order to update the view.
+  $scope.$on('pinPlaced', function(event, addr){=
+    self.readable_location = addr;
+    userSession.readable_location = addr;
+  });
 });

--- a/www/js/sidemenu/MenuCtrl.js
+++ b/www/js/sidemenu/MenuCtrl.js
@@ -127,9 +127,8 @@ angular.module('snapcache.menu', [])
     watchID = navigator.geolocation.watchPosition(function(pos) {
       console.log('current position:', pos);
       userSession.position = pos;
-      self.position = pos;
 
-      // remove key in order to satisfy the 'key entered' event
+      // Remove key in order to satisfy the 'key entered' event
       // (when key already inside radius)
       Geofire.geofire.remove(userSession.uid);
       Geofire.geofire.set(userSession.uid, [
@@ -152,4 +151,23 @@ angular.module('snapcache.menu', [])
     // remove user from geofire
     Geofire.geofire.remove(userSession.uid);
   };
+
+  // Set the user's initial position so that it is in line with what
+  // is displayed when they open up the map view.
+  navigator.geolocation.getCurrentPosition(function(pos){
+    var lat = pos.coords.latitude;
+    var lon = pos.coords.longitude;
+
+    // Get the address
+    Location.getAddress(lat, lon).then(function(addr){
+      self.readable_location = addr;
+      userSession.readable_location = addr;
+      console.log('your addr is', addr);
+    });
+
+    // Store the user's location
+    self.position = pos;
+    userSession.position = pos;
+  });
+
 });

--- a/www/js/snapcache.js
+++ b/www/js/snapcache.js
@@ -18,6 +18,7 @@ angular.module('snapcache', [
   'snapcache.services.auth',
   'snapcache.services.geofire',
   'snapcache.services.userFriends',
+  'snapcache.services.location',
   'angularMoment'
 ])
 


### PR DESCRIPTION
In addition, this pull request creates a new service, Location, that currently has one function: `getAddress()`. It also will set the readable location to the user's current location, which agrees with where the pin defaults.

This means that someone could create a cache without going to the map view, and it should still have coordinates associated with it.
