### PR TITLE
(fix) Protect against location not being acquired soon enough

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -77,4 +77,7 @@
         <param name="APP_ID" value="800556536702390" />
         <param name="APP_NAME" value="Snapcache" />
     </feature>
+    <feature name="Camera">
+        <param name="id" value="org.apache.cordova.camera" />
+    </feature>
 </widget>

--- a/www/js/create/CreateCtrl.js
+++ b/www/js/create/CreateCtrl.js
@@ -102,11 +102,16 @@ angular.module('snapcache.create', [])
   // Cache will have the `discovered` property set to false
   self.properties.discovered = false;
 
-  // Want to use the user's current location as the default location
-  self.properties.coordinates = {
-    latitude: userSession.position.coords.latitude,
-    longitude: userSession.position.coords.longitude
-  };
+  // Want to use the user's current location as the default location. However,
+  // it is possible that the GPS location has not been acquired, so we need
+  // to listen for when that event has happened.
+  $scope.$on('locationAcquired', function(event, pos){
+    console.log('position has been acquired');
+    self.properties.coordinates = {
+      latitude: pos.coords.latitude,
+      longitude: pos.coords.longitude
+    };
+  });
 
   // `convertDateTime()` will take the user provided input and convert it to
   // milliseconds. To do this, it also has to know what date the user selected.

--- a/www/js/sidemenu/MenuCtrl.js
+++ b/www/js/sidemenu/MenuCtrl.js
@@ -168,6 +168,11 @@ angular.module('snapcache.menu', [])
     // Store the user's location
     self.position = pos;
     userSession.position = pos;
+
+    // Broadcast an event so that the child scope can update its
+    // self.properties.coordinates in case the user has quickly navigated
+    // to that view.
+    $scope.$broadcast('locationAcquired', pos);
   });
 
   // Listen for `pinPlaced` events so that we know we can set the


### PR DESCRIPTION
We're still making the assumption that location will get acquired (meaning I haven't set any defaults). Right now, it works by broadcasting an event with location is acquired. See commit message for more detail.
