### PR TITLE
(refactor) Ensure real-time updates for Outbox and Outbox Detail

### DIFF
--- a/www/js/shared/CachesService.js
+++ b/www/js/shared/CachesService.js
@@ -8,7 +8,6 @@ angular.module('snapcache.services.caches', [])
   var usersRef = new Firebase(FIREBASE_REF).child('users');
 
   return {
-    getContributable: getContributable,
     getReceived: getReceived,
     getCacheDetails: getCacheDetails,
     getCacheDetailsForDiscovered: getCacheDetailsForDiscovered,
@@ -19,25 +18,6 @@ angular.module('snapcache.services.caches', [])
     discoverCache: discoverCache,
     removeCache: removeCache
   };
-
-  // `getContributable()` will get the current user's caches that they can
-  // contribute to from Firebase.
-  function getContributable() {
-    var id = userSession.uid;
-    var deferred = $q.defer();
-    usersRef.child(id).once('value', function(snapshot){
-      var userData = snapshot.val();
-      var contributableCaches = userData.contributableCaches;
-      if (contributableCaches) {
-        deferred.resolve(contributableCaches);
-      } else {
-        // If the user has no contributable caches, the promise will return
-        // an empty object.
-        deferred.reject({});
-      }
-    });
-    return deferred.promise;
-  }
 
   // `getReceived()` will simply get the current user's received caches from Firebase.
   // This current version does not do any type of geographic or temporal filtering,

--- a/www/js/snapcache.js
+++ b/www/js/snapcache.js
@@ -6,6 +6,7 @@
 // 'starter.controllers' is found in controllers.js
 angular.module('snapcache', [
   'ionic',
+  'firebase',
   'snapcache.auth',
   'snapcache.menu',
   'snapcache.inbox',


### PR DESCRIPTION
In Outbox Detail, we use Angular Fire so that whenever any user adds an item to the cache, it is immediately visible to all users with that detail open.

In Outbox, we setup a Firebase listener for 'child_added', which is run initially whenever the user opens the outbox, and every time a cache is added. This ensures that whenever the user creates a cache, or when someone invites him/her to a cache, that it is immediately available.

`getContributable` has been removed from CachesService since it is no longer being used.

Closes #211
