### PR TITLE
(feat) Immediately upload user-chosen image content

### DIFF
--- a/www/js/detail/OutboxDetailCtrl.js
+++ b/www/js/detail/OutboxDetailCtrl.js
@@ -76,7 +76,7 @@ angular.module('snapcache.detail.outbox', [])
             console.log('SUCCESSFUL POST TO CLOUDINARY');
             self.hideLoading();
             self.contentToAdd.imgURL = response.url; // could be secure_url if we need https
-
+            self.addContent();
           }).error(function(error) {
             console.log('ERROR POSTING TO CLOUDINARY');
             console.error('getPhoto error', error);
@@ -105,8 +105,8 @@ angular.module('snapcache.detail.outbox', [])
   self.showContentActionSheet = function () {
     var hideSheet = $ionicActionSheet.show({
       buttons: [
-        { text: 'Take Photo' },
-        { text: 'Choose from Libary' }
+        { text: 'Post a Photo' },
+        { text: 'Post Existing Photo' }
       ],
       cancelText: 'Cancel',
       cancel: function () {


### PR DESCRIPTION
Calling addContent() from within the photo selection function keeps
us from uploading images that don't end up getting used if the user
decides to cancel out of the detail view without hitting the submit
button. Since there's already a confirmation within the image
selection and capture process, it's unnecessary to require the user
to confirm again. The current submit button is only for adding text-
only content, now.

Note: if a user enters text before selecting an image, that text will
still get uploaded as a caption with the image. We may wish to remove
that down the line.
- closes #196
